### PR TITLE
Adding basic mobile first approach

### DIFF
--- a/frontend/src/components/styled/index.js
+++ b/frontend/src/components/styled/index.js
@@ -1,4 +1,18 @@
 import styled, { css } from "styled-components";
+const sizes = {
+  desktop: 1200,
+  tablet: 768,
+  phone: 576
+};
+
+const media = Object.keys(sizes).reduce((acc, label) => {
+  acc[label] = (...args) => css`
+    @media (min-width: ${sizes[label] / 16}em) {
+      ${css(...args)}
+    }
+  `;
+  return acc;
+}, {});
 
 export const Hero = styled.div`
   width: 100%;
@@ -14,17 +28,19 @@ export const Hero = styled.div`
 
 export const FlexContainer = styled.div`
   display: flex;
+  flex-direction: column;
+  ${media.desktop`flex-direction: row;`}
 `;
 
 export const ColumnContainer = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  width: 20vw;
-  margin: 1em;
+  margin: 1em 0.2em 1em 0.2em;
+  ${media.tablet`margin: 1em 1em 1em 1em;`}
   border: 1px solid grey;
   border-radius: 2px;
-  background-color: white;
+  background-color: #white;
   box-shadow: 0 6px 6px -2px lightgrey;
 `;
 
@@ -67,7 +83,8 @@ export const Unblur = styled.a`
 export const ItemsContainerStyles = css`
   flex-grow: 1;
   min-height: 100px;
-  padding: 1em;
+  padding: 0.2em;
+  ${media.tablet`padding: 1em;`}
   background-color: ${p => (p.isDraggingOver ? "#f5f5f5" : "inherit")};
   transition: background-color 0.2s ease;
 `;


### PR DESCRIPTION
This PR changes the default style to a single column design with lower margins and paddings. This allows mobile user to use the app. 
Media queries alter the design when a given minimum screen size is given. Margins and padding get bigger when the device is at least a table. Multiple Columns on one page are activated at desktop size.